### PR TITLE
fix: Allow traffic form an external node IP to pass through the tunnel

### DIFF
--- a/internal/annotation/annotation.go
+++ b/internal/annotation/annotation.go
@@ -2,5 +2,5 @@ package annotation
 
 const (
 	PublicKeyAnnotation string = "wigglenet/public-key"
-	NodeIpAnnotation    string = "wigglenet/node-ip"
+	NodeIpsAnnotation   string = "wigglenet/node-ips"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,32 +2,80 @@ package config
 
 import (
 	"os"
+	"strconv"
+)
 
-	"github.com/tibordp/wigglenet/internal/util"
+type IPFamily string
+
+const (
+	IPv4Family      IPFamily = "ipv4"
+	IPv6Family      IPFamily = "ipv6"
+	DualStackFamily IPFamily = "dual"
 )
 
 var (
 	CurrentNodeName string = os.Getenv("NODE_NAME")
 
 	// Wireguard network settings
-	WGLinkName         string = util.GetEnvOrDefault("WIGGLENET_IFACE_NAME", "wigglenet")
-	WGPort             int    = util.GetEnvOrDefaultInt("WIGGLENET_WG_PORT", 24601)
-	PrivateKeyFilename string = util.GetEnvOrDefault("WIGGLENET_PRIVKEY_PATH", "/etc/wigglenet/private.key")
+	WGLinkName         string = GetEnvOrDefault("WIGGLENET_IFACE_NAME", "wigglenet")
+	WGPort             int    = GetEnvOrDefaultInt("WIGGLENET_WG_PORT", 24601)
+	PrivateKeyFilename string = GetEnvOrDefault("WIGGLENET_PRIVKEY_PATH", "/etc/wigglenet/private.key")
+
+	// Which IP family to use for the tunnel (relevant for dual-stack clusters)
+	WireguardIPFamily IPFamily = IPFamily(GetEnvOrDefault("WG_IP_FAMILY", "dual"))
 
 	// CNI settings
-	CniConfigPath string = util.GetEnvOrDefault("CNI_CONFIG_PATH", "/etc/cni/net.d/10-wigglenet.conflist")
+	CniConfigPath string = GetEnvOrDefault("CNI_CONFIG_PATH", "/etc/cni/net.d/10-wigglenet.conflist")
 
 	// Firewall settings
-	MasqueradeIPv4 bool = util.GetEnvOrDefaultBool("MASQUERADE_IPV4", true)
-	FilterIPv4     bool = util.GetEnvOrDefaultBool("FILTER_IPV4", false)
-	MasqueradeIPv6 bool = util.GetEnvOrDefaultBool("MASQUERADE_IPV6", true)
-	FilterIPv6     bool = util.GetEnvOrDefaultBool("FILTER_IPV6", false)
+	MasqueradeIPv4 bool = GetEnvOrDefaultBool("MASQUERADE_IPV4", true)
+	FilterIPv4     bool = GetEnvOrDefaultBool("FILTER_IPV4", false)
+	MasqueradeIPv6 bool = GetEnvOrDefaultBool("MASQUERADE_IPV6", true)
+	FilterIPv6     bool = GetEnvOrDefaultBool("FILTER_IPV6", false)
 
-	// Auto detection of node IP
-	NodeIPInterface string        = util.GetEnvOrDefault("NODE_IP_INTERFACE", "")
-	NodeIPFamily    util.IPFamily = util.IPFamily(util.GetEnvOrDefault("NODE_IP_FAMILY", "dual"))
+	// Auto detection of node IP. Take addresses from these comma-separated to be used as node's IP
+	// addresses. This option is mainly to work around limitations of kubelet and many cloud controllers
+	// that only set a single IP for dual-stack nodes.
+	NodeIPInterfaces string = GetEnvOrDefault("NODE_IP_INTERFACES", "")
 
 	// Do not install Wireguard and CNI configuration, instead only install firewall rules
-	FirewallOnly  bool = util.GetEnvOrDefaultBool("FIREWALL_ONLY", false)
-	NativeRouting bool = util.GetEnvOrDefaultBool("NATIVE_ROUTING", false)
+	FirewallOnly bool = GetEnvOrDefaultBool("FIREWALL_ONLY", false)
+
+	// Native routing. Wireguard tunnel will not be used for the specified address families
+	NativeRoutingIPv6 bool = GetEnvOrDefaultBool("NATIVE_ROUTING_IPV6", false)
+	NativeRoutingIPv4 bool = GetEnvOrDefaultBool("NATIVE_ROUTING_IPV4", false)
+
+	NativeRouting = NativeRoutingIPv4 && NativeRoutingIPv6 // Completely disable Wireguard functionality if both are set
 )
+
+func GetEnvOrDefault(name string, fallback string) string {
+	if val, ok := os.LookupEnv(name); ok {
+		return val
+	} else {
+		return fallback
+	}
+}
+
+func GetEnvOrDefaultInt(name string, fallback int) int {
+	if val, ok := os.LookupEnv(name); ok {
+		if i, err := strconv.Atoi(val); err != nil {
+			return fallback
+		} else {
+			return i
+		}
+	} else {
+		return fallback
+	}
+}
+
+func GetEnvOrDefaultBool(name string, fallback bool) bool {
+	if val, ok := os.LookupEnv(name); ok {
+		if i, err := strconv.ParseBool(val); err != nil {
+			return fallback
+		} else {
+			return i
+		}
+	} else {
+		return fallback
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,109 @@
+package controller
+
+import (
+	"net"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tibordp/wigglenet/internal/wireguard"
+)
+
+func parseCIDR(cidr string) net.IPNet {
+	_, c, _ := net.ParseCIDR(cidr)
+	return *c
+}
+
+func TestMakePeer2(t *testing.T) {
+	result := makePeer(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"wigglenet/public-key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+				"wigglenet/node-ips":   `["192.168.0.1","2001:db8::1234"]`,
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "2001:db8::/64",
+			PodCIDRs: []string{
+				"2001:db8::/64",
+				"10.0.0.0/24",
+			},
+		},
+	})
+
+	expected := &wireguard.Peer{
+		Endpoint: net.ParseIP("192.168.0.1"),
+		NodeCIDRs: []net.IPNet{
+			parseCIDR("192.168.0.1/32"),
+			parseCIDR("2001:db8::1234/128"),
+		},
+		PodCIDRs: []net.IPNet{
+			parseCIDR("2001:db8::/64"),
+			parseCIDR("10.0.0.0/24"),
+		},
+		PublicKey: []uint8{
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+			11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+			21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+			31,
+		},
+	}
+
+	assert.Equal(t, expected, result)
+}
+
+func TestMakePeerInvalid(t *testing.T) {
+	result := makePeer(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"wigglenet/public-key": "AAECAwQFBgcICQoLwdHh8=",
+				"wigglenet/node-ips":   `["192.168.0.1","2001:db8::1234"]`,
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "2001:db8::/64",
+			PodCIDRs: []string{
+				"2001:db8::/64",
+				"10.0.0.0/24",
+			},
+		},
+	})
+
+	assert.Nil(t, result)
+}
+
+func TestMakePeerInvalid1(t *testing.T) {
+	result := makePeer(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"wigglenet/public-key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+				"wigglenet/node-ips":   `["192.168.0.1","2001:db8::12345678"]`,
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "2001:db8::/64",
+			PodCIDRs: []string{
+				"2001:db8::/64",
+				"10.0.0.0/24",
+			},
+		},
+	})
+
+	assert.Nil(t, result)
+}
+
+func TestMakePeerInvalid2(t *testing.T) {
+	result := makePeer(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"wigglenet/public-key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+				"wigglenet/node-ips":   `["192.168.0.1","2001:db8::1234"]`,
+			},
+		},
+		Spec: v1.NodeSpec{},
+	})
+
+	assert.Nil(t, result)
+}

--- a/internal/firewall/firewall_test.go
+++ b/internal/firewall/firewall_test.go
@@ -26,6 +26,7 @@ func TestSyncFilter(t *testing.T) {
 	).Return(true, nil)
 
 	mockIptables.On("RestoreAll", []byte(`*filter
+-F WIGGLENET-FIREWALL
 :WIGGLENET-FIREWALL - [0:0]
 -A WIGGLENET-FIREWALL -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
 -A WIGGLENET-FIREWALL -p ipv6-icmp -j RETURN
@@ -51,6 +52,7 @@ func TestSyncNat(t *testing.T) {
 		"--comment", "masquerade non-LOCAL traffic",
 	).Return(true, nil)
 	mockIptables.On("RestoreAll", []byte(`*nat
+-F WIGGLENET-MASQ
 :WIGGLENET-MASQ - [0:0]
 -A WIGGLENET-MASQ -d 2001:db8::/64 -j RETURN
 -A WIGGLENET-MASQ -j MASQUERADE

--- a/internal/util/subnets.go
+++ b/internal/util/subnets.go
@@ -91,7 +91,9 @@ func summarizeSubnets(subnets []net.IPNet, ipv6 bool) []net.IPNet {
 	markers := make([]marker, 0)
 	// convert IP networks into interval endpoints
 	for _, network := range subnets {
-		if network.IP.To4() == nil == ipv6 {
+		// Do not use .To4() check here. We specifically want to treat
+		// ::ffff:a.b.c.d/x as an IPv6 subnet.
+		if (len(network.IP) == net.IPv6len) == ipv6 {
 			markers = append(markers,
 				marker{
 					bound: getUpperBound(network.IP, network.Mask),

--- a/internal/util/subnets_test.go
+++ b/internal/util/subnets_test.go
@@ -81,3 +81,19 @@ func TestSummarizeSubnetsWholeNet(t *testing.T) {
 	results := SummarizeSubnets(subnets)
 	assert.Equal(t, expected, results)
 }
+
+func TestSummarizeSubnetsEmbedded(t *testing.T) {
+	subnets := []net.IPNet{
+		parseCIDR("192.168.0.0/16"),
+		parseCIDR("::ffff:192.168.0.0/120"),
+		parseCIDR("::ffff:192.168.1.0/120"),
+	}
+
+	expected := []net.IPNet{
+		parseCIDR("::ffff:192.168.0.0/119"),
+		parseCIDR("192.168.0.0/16"),
+	}
+
+	results := SummarizeSubnets(subnets)
+	assert.Equal(t, expected, results)
+}

--- a/testing/manifest.yaml
+++ b/testing/manifest.yaml
@@ -79,6 +79,8 @@ spec:
           value: "false" 
           # Optional interface from which to take the node's
           # IP address (default: none)   
+        - name: NODE_IP_INTERFACES
+          value: eth0
         volumeMounts:
         - name: cfg
           mountPath: /etc/wigglenet


### PR DESCRIPTION
`Endpoints` for the default `kubernetes` service will contain external IP address, so if masquerading is turned off, the packets going from pod to the master node will be routed directly. However on the way back, they will be routed through the Wireguard tunnel, as per the routing logic. But - the external node IP is not on the wireguard's allow-list, so the packets are dropped.

If the traffic originated on the node, it would not be an issue, as the internal source IP of the wireguard interface would be selected, so everything would work as usual and go through the tunnel.

This is only an issue when masquerading is not used.

This fix adds the external IPs of the node to the allow list (without actually adding the routes).