### PR TITLE
fix: Setup node annotations even if native routing or firewall-only modes are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Wigglenet runs as a daemonset on every node and does the following things:
 - Initializes each new node on startup, sets up the Wireguard interface and writes the CNI configuration
 - Runs a controller on each node that adjusts the Wireguard peer configuration, local routing table and iptables rules for filtering and masquerading as nodes come and go
 
+Wigglenet explicitely supports and encourages allocation of public IPv6 addresses to pods and offers a variety of pod network selection methods. See [Pod network selection](./docs/configuration.md#pod-network-selection) for details.
+
 ## Installation
 
 To install Wigglenet on a dual-stack cluster with the default settings:
@@ -24,55 +26,17 @@ To install Wigglenet on a dual-stack cluster with the default settings:
 kubectl apply -f https://raw.githubusercontent.com/tibordp/wigglenet/v0.2.0/deploy/manifest.yaml
 ```
 
-For customization and other configuration options see notes below and [the manifest](./deploy/manifest.yaml) for full reference.
+The default configuration should work out of the box for a cluster created with kubeadm using [the official dual-stack tutorial](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/dual-stack-support/). It will enable masquerading for both IPv6 and IPv4 addresses. 
+
+Use the following manifest if the cluster is single-stack (IPv6 only):
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/tibordp/wigglenet/v0.2.0/deploy/ipv6_only.yaml
+```
 
 ## Configuration
 
-### Pod network selection
-
-In the default configuration Wigglenet uses the networks specified in `.spec.podCIDRs` (or `.spec.podCIDR`) for each node. These CIDRs are allocated by kube-controller-manager from the cluster-wide pod network specified in the `--pod-network-cidr` in case cluster was provisioned with kubeadm. 
-
-This approach of having a single prefix for the whole cluster works in many cases well for IPv4 clusters, since pod networks almost always consist of RFC1918 addresses. In the case of IPv6, however, use of public addresses is generally preferred even for private networks. This [presents a problem](https://github.com/kubernetes/kubernetes/issues/57130), since it can be hard to foresee what IPv6 network will be available to each node at the time of cluster creation.
-
-AWS provides a /56 network for each VPC, which can be used as the basis for `--pod-network-cidr` but some cloud providers such as Hetzner and Digital Ocean provide a routable IPv6 network to each instance which is dynamically assigned at instance creation and cannot be customized, which precludes use of `--pod-network-cidr` other than ::/0 (which wouldn't work anyway).
-
-Wigglenet does not rely on a single contiguous pod network and it supports different ways of selecting the source per address family. This is controlled by `POD_CIDR_SOURCE_IPV4` and `POD_CIDR_SOURCE_IPV6` environment variables, which can take the following values:
-
-- `none` - Wigglenet will not assign pods addresses of this family
-- `spec` - use the relevant networks from `.spec.podCIDR` (default for both IPv4 and IPv6)
-- `file` - read the prefixes from a file specified by `POD_CIDR_SOURCE_PATH` environment variable. File format is one network in CIDR format per line.
-
-A use case for `file` mode is to have a [cloud-init](https://cloudinit.readthedocs.io/en/latest/) script determine the instance's routed IPv6 prefix and write it to a predetermined file on the host filesystem. Since the mode is independently selectable for each address family, this allows for additional flexibility for dynamic clusters where nodes are constantly joining and leaving.
-
-kube-controller-manager can be used to automatically assign RFC1918 IPv4 node subnets and IPv6 ones can be determined by the method above, e.g.:
-
-```
-kind: ClusterConfiguration
-apiVersion: kubeadm.k8s.io/v1beta2
-networking:
-    # This will not actually be a single-stack cluster, as Wireguard
-    # will assign an additional IPv6 subnet to each node
-    podSubnet: "10.96.0.0/16"
-
-    # Despite what I said above, services should still use an ULA subnet as
-    # their IPs are never used as a source address and only have meaning
-    # in context of each individual node.
-    serviceSubnet: fd00::/112,172.16.0.0/16
-```
-
-In the future Wireguard may provide additional modes, such as automatic network discovery based on uplink network interface or other metadata provided by the cloud provider.
-
-### Firewall configuration
-
-Masquerading can be switched on or off per address family by `MASQUERADE_IPV4` and `MASQUERADE_IPV6` environment variables. If Wireguard is set up to hand out public IPv6 addresses to pods, masquerading should be turned off for IPv6.
-
-There are two additional options that control the firewall rules: `FILTER_IPV4` and `FILTER_IPV6`. If set to true, Wireguard will install basic stateful firewall rules for that address family preventing direct connectivity to pods from outside the cluster (egress traffic is not affected and neither are workloads exposed through NodePort and LoadBalancer services).
-
-### Firewall only mode and native routing
-
-Wigglenet can run in a firewall-only mode by passing `FIREWALL_ONLY=1` environment variable. Running in this mode will not provision a Wireguard tunnel and CNI configuration, but will only filter and masquerade traffic, similar to [ip-masq-agent](https://github.com/kubernetes-sigs/ip-masq-agent). Unlike `ip-masq-agent`, Wigglenet will automatically determine all the pod CIDRs that should not be masqueraded or filtered by watching Node objects, allowing for flexible subnetting.
-
-Native routing is configured (`NATIVE_ROUTING_IPV4=1` / `NATIVE_ROUTING_IPV6=1`). Run in this mode, native routing will only be used for the selected address family instead of the Wireguard overlay. This assumes that there is something outside of the cluster that knows how to route packets for pods to the appropriate node, as generally the pod-to-pod traffic will be forwarded along the default route on each node.
+For configuration options see [the docs](./docs/configuration.md)
 
 ## Limitations
 
@@ -89,9 +53,19 @@ go build ./...
 go test ./...
 ```
 
-See [Makefile](./Makefile) and [example manifests](./testing) for experimenting with Wigglenet locally using kind.
+See [Makefile](./Makefile) and [example manifests](./testing) for experimenting with Wigglenet locally using [kind](https://kind.sigs.k8s.io/). For example:
 
+```bash
+# Create a dual-stuck kind cluster with default settings
+make kind-default
+
+# Build Docker image and load it to all the nodes
+make image
+
+# Install Wigglenet
+make deploy
+```
 
 ## Acknowledgements
 
-Wigglenet is inspired by [kindnet](https://github.com/kubernetes-sigs/kind/tree/main/images/kindnetd), the default network plugin for [kind](https://kind.sigs.k8s.io/).
+Wigglenet is inspired by [kindnet](https://github.com/kubernetes-sigs/kind/tree/main/images/kindnetd), kind's default network plugin.

--- a/deploy/ipv6_only.yaml
+++ b/deploy/ipv6_only.yaml
@@ -54,29 +54,63 @@ spec:
       serviceAccountName: wigglenet
       containers:
       - name: wigglenet
-        image: wigglenet
-        imagePullPolicy: Never
+        image: tibordp/wigglenet:0.2.0
+        imagePullPolicy: Always
         env:
+          # Masquerade outgoing IPv4 traffic not destined
+          # to pod on another node
+        - name: MASQUERADE_IPV4
+          value: "0"
+
+          # Masquerade outgoing IPv6 traffic not destined
+          # to pod on another node          
+        - name: MASQUERADE_IPV6
+          value: "1"
+
+          # Filter direct IPv4 traffic to pods from
+          # outside the cluster
+        - name: FILTER_IPV4
+          value: "0"
+
+          # Filter direct IPv6 traffic to pods from
+          # outside the cluster          
+        - name: FILTER_IPV6
+          value: "0" 
+
+          # Optional interface from which to take the node's
+          # host IP address (default: none)
+        - name: NODE_IP_INTERFACES
+          value: ""
+
+          # The source of IPv6 subnets for node pod networks
+          # ("none", "spec", "file")
+        - name: POD_CIDR_SOURCE_IPV4
+          value: "none"
+
+          # The source of IPv4 subnets for node pod networks
+          # ("none", "spec", "file")
+        - name: POD_CIDR_SOURCE_IPV6
+          value: "spec"
+
+          # The file from which to read the pod CIDRs if "file"
+          # mode is used
+        - name: POD_CIDR_SOURCE_PATH
+          value: "/etc/wigglenet/cidrs.txt"
+
+          # Use native routing instead of the overlay network
+          # for IPv6 traffic
+        - name: NATIVE_ROUTING_IPV6
+          value: "0"
+
+          # Use native routing instead of the overlay network
+          # for IPv4 traffic
+        - name: NATIVE_ROUTING_IPV4
+          value: "1"
+        
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: MASQUERADE_IPV4
-          value: "true"      
-        - name: MASQUERADE_IPV6
-          value: "true"
-        - name: FILTER_IPV4
-          value: "false"      
-        - name: FILTER_IPV6
-          value: "false" 
-        - name: NODE_IP_INTERFACES
-          value: eth0
-        - name: POD_CIDR_SOURCE_IPV6
-          value: file
-        - name: POD_CIDR_SOURCE_IPV4
-          value: spec
-        - name: POD_CIDR_SOURCE_PATH
-          value: /etc/wigglenet/cidrs.txt
         volumeMounts:
         - name: cfg
           mountPath: /etc/wigglenet

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,55 @@
+# Configuration
+
+## Pod network selection
+
+In the default configuration Wigglenet uses the networks specified in `.spec.podCIDRs` (or `.spec.podCIDR`) for each node. These CIDRs are allocated by kube-controller-manager from the cluster-wide pod network specified in the `--pod-network-cidr` in case cluster was provisioned with kubeadm. 
+
+This approach of having a single prefix for the whole cluster works in many cases well for IPv4 clusters, since pod networks almost always consist of RFC1918 addresses. In the case of IPv6, however, use of public addresses is generally preferred even for private networks. This [presents a problem](https://github.com/kubernetes/kubernetes/issues/57130), since it can be hard to foresee what IPv6 network will be available to each node at the time of cluster creation.
+
+AWS provides a /56 network for each VPC, which can be used as the basis for `--pod-network-cidr` but some cloud providers such as Hetzner and Digital Ocean provide a routable IPv6 network to each instance which is dynamically assigned at instance creation and cannot be customized, which precludes use of `--pod-network-cidr` other than ::/0 (which wouldn't work anyway).
+
+Wigglenet does not rely on a single contiguous pod network and it supports different ways of selecting the source per address family. This is controlled by `POD_CIDR_SOURCE_IPV4` and `POD_CIDR_SOURCE_IPV6` environment variables, which can take the following values:
+
+- `none` - Wigglenet will not assign pods addresses of this family
+- `spec` - use the relevant networks from `.spec.podCIDR` (default for both IPv4 and IPv6)
+- `file` - read the prefixes from a file specified by `POD_CIDR_SOURCE_PATH` environment variable. File format is one network in CIDR format per line.
+
+A use case for `file` mode is to have a [cloud-init](https://cloudinit.readthedocs.io/en/latest/) script determine the instance's routed IPv6 prefix and write it to a predetermined file on the host filesystem. Since the mode is independently selectable for each address family, this allows for additional flexibility for dynamic clusters where nodes are constantly joining and leaving.
+
+kube-controller-manager can be used to automatically assign RFC1918 IPv4 node subnets and IPv6 ones can be determined by the method above, e.g.:
+
+```
+kind: ClusterConfiguration
+apiVersion: kubeadm.k8s.io/v1beta2
+networking:
+    # This will not actually be a single-stack cluster, as Wigglenet
+    # will assign an additional IPv6 subnet to each node
+    podSubnet: "10.96.0.0/16"
+
+    # Despite what I said above, services should still use an ULA subnet as
+    # their IPs are never used as a source address and only have meaning
+    # in context of each individual node.
+    serviceSubnet: fd00::/112,172.16.0.0/16
+```
+
+In the future Wireguard may provide additional modes, such as automatic network discovery based on uplink network interface or other metadata provided by the cloud provider.
+
+## Firewall configuration
+
+Masquerading can be switched on or off per address family by `MASQUERADE_IPV4` and `MASQUERADE_IPV6` environment variables. If Wireguard is set up to hand out public IPv6 addresses to pods, masquerading should be turned off for IPv6.
+
+There are two additional options that control the firewall rules: `FILTER_IPV4` and `FILTER_IPV6`. If set to true, Wireguard will install basic stateful firewall rules for that address family preventing direct connectivity to pods from outside the cluster (egress traffic is not affected and neither are workloads exposed through NodePort and LoadBalancer services).
+
+## Firewall only mode and native routing
+
+Wigglenet can run in a firewall-only mode by passing `FIREWALL_ONLY=1` environment variable. Running in this mode will not provision a Wireguard tunnel and CNI configuration, but will only filter and masquerade traffic, similar to [ip-masq-agent](https://github.com/kubernetes-sigs/ip-masq-agent). Unlike `ip-masq-agent`, Wigglenet will automatically determine all the pod CIDRs that should not be masqueraded or filtered by watching Node objects, allowing for flexible subnetting.
+
+Native routing is configured (`NATIVE_ROUTING_IPV4=1` / `NATIVE_ROUTING_IPV6=1`). Run in this mode, native routing will only be used for the selected address family instead of the Wireguard overlay. This assumes that there is something outside of the cluster that knows how to route packets for pods to the appropriate node, as generally the pod-to-pod traffic will be forwarded along the default route on each node.
+
+## Node address selection
+
+Wigglenet needs to be aware of the node's host address(es) in order to know where to terminate the Wireguard tunnel. In addition, node addresses need to be set as an allowed source IP in order to allow communication between the host and a pod running on another node. 
+
+By default, Wigglenet takes all the `ExternalIP` and `InternalIP` entries from the Node object and then uses the first one as the tunnel endpoint. Some cloud providers may not populate the fields correctly (e.g. only put IPv4 address there, even though the cluster is dual-stack). To work around this, Wigglenet can be configured to additionaly take the node addresses from the network interfaces. The `NODE_IP_INTERFACES` environment variable takes a comma-separated list of interfaces to consider as sources of node addresses. Only global unicast addresses will be considered (this includes RFC1918 and ULA addresses, but excludes link-local and multicast addresses).
+
+To force the Wireguard tunnel to use an address of a particular family as the endpoint, pass `WG_IP_FAMILY={ipv4,ipv6,dualstack}` (`dualstack` is the default).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ type IPFamily string
 const (
 	IPv4Family      IPFamily = "ipv4"
 	IPv6Family      IPFamily = "ipv6"
-	DualStackFamily IPFamily = "dual"
+	DualStackFamily IPFamily = "dualstack"
 )
 
 var (
@@ -30,7 +30,7 @@ var (
 	PrivateKeyFilename string = GetEnvOrDefault("WIGGLENET_PRIVKEY_PATH", "/etc/wigglenet/private.key")
 
 	// Which IP family to use for the tunnel (relevant for dual-stack clusters)
-	WireguardIPFamily IPFamily = IPFamily(GetEnvOrDefault("WG_IP_FAMILY", "dual"))
+	WireguardIPFamily IPFamily = IPFamily(GetEnvOrDefault("WG_IP_FAMILY", "dualstack"))
 
 	// CNI settings
 	CniConfigPath string = GetEnvOrDefault("CNI_CONFIG_PATH", "/etc/cni/net.d/10-wigglenet.conflist")

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"net"
 	"strings"
 
@@ -126,6 +127,26 @@ func GetInterfaceIPs(ifaces string) ([]net.IP, error) {
 		}
 	}
 	return ipAddresses, nil
+}
+
+func IPCompare(a, b net.IP) int {
+	aV4 := a.To4()
+	bV4 := b.To4()
+
+	if (aV4 != nil) != (bV4 != nil) {
+		if aV4 != nil {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	if aV4 != nil {
+		// Make sure that ::ffff:a.b.c.d compares equal to a.b.c.d
+		return bytes.Compare(aV4, bV4)
+	} else {
+		return bytes.Compare(a, b)
+	}
 }
 
 func GetNodeAddresses(node *v1.Node) []net.IP {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPCompare(t *testing.T) {
+	cidrs := []net.IP{
+		net.ParseIP("2001:db8:0:3::1"),
+		net.ParseIP("2001:db8:0:1::1"),
+		net.ParseIP("2001:db8:0:2::1"),
+		net.ParseIP("192.168.3.0"),
+		net.ParseIP("192.168.4.0"),
+		net.ParseIP("2001:db8:0:4::1"),
+		net.ParseIP("192.168.1.0"),
+		net.ParseIP("192.168.2.0"),
+	}
+
+	expected := []net.IP{
+		net.ParseIP("2001:db8:0:1::1"),
+		net.ParseIP("2001:db8:0:2::1"),
+		net.ParseIP("2001:db8:0:3::1"),
+		net.ParseIP("2001:db8:0:4::1"),
+		net.ParseIP("192.168.1.0"),
+		net.ParseIP("192.168.2.0"),
+		net.ParseIP("192.168.3.0"),
+		net.ParseIP("192.168.4.0"),
+	}
+
+	sort.Slice(cidrs, func(i, j int) bool {
+		return IPCompare(cidrs[i], cidrs[j]) < 0
+	})
+
+	assert.Equal(t, expected, cidrs)
+}

--- a/internal/wireguard/wireguard.go
+++ b/internal/wireguard/wireguard.go
@@ -64,7 +64,7 @@ func (c *WireguardConfig) canonicalize() {
 	// Sort the peers so that the slice of peers will not change
 	// under deep comparison.
 	sort.Slice(c.Addresses, func(i, j int) bool {
-		return bytes.Compare(c.Addresses[i], c.Addresses[j]) < 0
+		return util.IPCompare(c.Addresses[i], c.Addresses[j]) < 0
 	})
 	sort.Slice(c.Peers, func(i, j int) bool {
 		return bytes.Compare(c.Peers[i].PublicKey, c.Peers[j].PublicKey) < 0
@@ -286,6 +286,7 @@ func ensurePrivateKey() (*wgtypes.Key, error) {
 			return nil, err
 		}
 
+		// Private key should only be readable by root
 		file, err = os.OpenFile(config.PrivateKeyFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return nil, err

--- a/testing/cluster_v6_singlestack.yaml
+++ b/testing/cluster_v6_singlestack.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: ipv6
+  disableDefaultCNI: true
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker


### PR DESCRIPTION
Currently if firewall-only or native routing modes are used, the node annotations are not setup. Since the pod CIDRs are only read from annotations, this leads to incorrect firewall rules.

This PR also makes sure node addresses are always sorted, so that consistent endpoint is used for Wiregard tunnel and improves docs.