### PR TITLE
feat: Reconcile Wireguard peers instead of overwriting them

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -174,8 +173,8 @@ func makePeer(node *v1.Node) *wireguard.Peer {
 		return nil
 	}
 
-	publicKey, err := base64.StdEncoding.DecodeString(publicKeyStr)
-	if err != nil || len(publicKey) != wgtypes.KeyLen {
+	publicKey, err := wgtypes.ParseKey(publicKeyStr)
+	if err != nil {
 		klog.Warningf("invalid public key for node %v", node.Name)
 		return nil
 	}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"testing"
 
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -37,7 +38,7 @@ func TestMakePeer2(t *testing.T) {
 			parseCIDR("2001:db8::/64"),
 			parseCIDR("10.0.0.0/24"),
 		},
-		PublicKey: []uint8{
+		PublicKey: wgtypes.Key{
 			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 			21, 22, 23, 24, 25, 26, 27, 28, 29, 30,

--- a/internal/wireguard/wireguard_test.go
+++ b/internal/wireguard/wireguard_test.go
@@ -1,0 +1,186 @@
+package wireguard
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+func parseKey(s string) wgtypes.Key {
+	key, _ := wgtypes.ParseKey(s)
+	return key
+}
+
+func parseCIDR(cidr string) net.IPNet {
+	_, c, _ := net.ParseCIDR(cidr)
+	return *c
+}
+
+func TestCreateChangesetNoChange(t *testing.T) {
+	existingPeers := []wgtypes.Peer{
+		{
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+			Endpoint:  &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 24601},
+			AllowedIPs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+		},
+	}
+
+	desiredPeers := []Peer{
+		{
+			Endpoint: net.ParseIP("192.168.0.1"),
+			PodCIDRs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+			NodeCIDRs: []net.IPNet{},
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+		},
+	}
+
+	actual := createPeerChangeset(existingPeers, desiredPeers)
+
+	assert.Len(t, actual, 0)
+}
+
+func TestCreateChangesetAdd(t *testing.T) {
+	existingPeers := []wgtypes.Peer{
+		{
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+			Endpoint:  &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 24601},
+			AllowedIPs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+		},
+	}
+
+	desiredPeers := []Peer{
+		{
+			Endpoint: net.ParseIP("192.168.0.1"),
+			PodCIDRs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+			NodeCIDRs: []net.IPNet{},
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+		},
+
+		{
+			Endpoint: net.ParseIP("192.168.1.1"),
+			PodCIDRs: []net.IPNet{
+				parseCIDR("192.168.1.0/24"),
+				parseCIDR("2001:db8:0:2::/64"),
+			},
+			NodeCIDRs: []net.IPNet{},
+			PublicKey: parseKey("oFFVKLsHSZ5BFTLdKxubHnvprQ5jdssnaW6nzaQMrGY="),
+		},
+	}
+
+	expected := []wgtypes.PeerConfig{
+		{
+			PublicKey:         parseKey("oFFVKLsHSZ5BFTLdKxubHnvprQ5jdssnaW6nzaQMrGY="),
+			Remove:            false,
+			UpdateOnly:        false,
+			Endpoint:          &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 24601},
+			ReplaceAllowedIPs: false,
+			AllowedIPs: []net.IPNet{
+				parseCIDR("192.168.1.0/24"),
+				parseCIDR("2001:db8:0:2::/64"),
+			},
+			PresharedKey:                nil,
+			PersistentKeepaliveInterval: nil,
+		},
+	}
+
+	actual := createPeerChangeset(existingPeers, desiredPeers)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateChangesetRemove(t *testing.T) {
+	existingPeers := []wgtypes.Peer{
+		{
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+			Endpoint:  &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 24601},
+			AllowedIPs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+		},
+	}
+
+	desiredPeers := []Peer{}
+
+	expected := []wgtypes.PeerConfig{
+		{
+			PublicKey:         parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+			Remove:            true,
+			UpdateOnly:        false,
+			Endpoint:          &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 24601},
+			ReplaceAllowedIPs: true,
+			AllowedIPs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+			PresharedKey:                nil,
+			PersistentKeepaliveInterval: nil,
+		},
+	}
+
+	actual := createPeerChangeset(existingPeers, desiredPeers)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateChangesetUpdate(t *testing.T) {
+	existingPeers := []wgtypes.Peer{
+		{
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+			Endpoint:  &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 24601},
+			AllowedIPs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+		},
+	}
+
+	desiredPeers := []Peer{
+		{
+			Endpoint: net.ParseIP("192.168.0.1"),
+			PodCIDRs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+			},
+			NodeCIDRs: []net.IPNet{
+				parseCIDR("2001:db8:1::1/128"),
+			},
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+		},
+	}
+
+	expected := []wgtypes.PeerConfig{
+		{
+			PublicKey:         parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+			Remove:            false,
+			UpdateOnly:        true,
+			Endpoint:          &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 24601},
+			ReplaceAllowedIPs: true,
+			AllowedIPs: []net.IPNet{
+				parseCIDR("192.168.0.0/24"),
+				parseCIDR("2001:db8:0:1::/64"),
+				parseCIDR("2001:db8:1::1/128"),
+			},
+			PresharedKey:                nil,
+			PersistentKeepaliveInterval: nil,
+		},
+	}
+
+	actual := createPeerChangeset(existingPeers, desiredPeers)
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
In certain cases overwriting Wireguard peers might lead to temporary loss of connectivity. This PR ensures that only peers that need to be changed are changed. This also has the added benefit of not resetting traffic counters. 