### PR TITLE
fix(nftables): scope firewall drop per address family

### DIFF
--- a/internal/firewall/nftables.go
+++ b/internal/firewall/nftables.go
@@ -250,34 +250,35 @@ func (c *nftablesManager) syncRules(ctx context.Context) error {
 			Rule:  "ct state established,related accept",
 		})
 
-		// Always allow ICMPv6
+		// Per-family filtering. The chain lives in an `inet` table and sees
+		// both address families, so each family's drop must be gated on
+		// `meta nfproto` — otherwise enabling FilterIPv6 alone would also
+		// drop all IPv4 forward traffic (and vice versa).
+		if config.FilterIPv4 {
+			tx.Add(&knftables.Rule{
+				Chain: nftFirewallChain,
+				Rule:  knftables.Concat("ip saddr", "@", nftPodCIDRsV4, "accept"),
+			})
+			tx.Add(&knftables.Rule{
+				Chain: nftFirewallChain,
+				Rule:  "meta nfproto ipv4 drop",
+			})
+		}
 		if config.FilterIPv6 {
 			tx.Add(&knftables.Rule{
 				Chain:   nftFirewallChain,
 				Rule:    "meta nfproto ipv6 meta l4proto icmpv6 accept",
 				Comment: knftables.PtrTo("allow ICMPv6 (RFC 4890)"),
 			})
-		}
-
-		// Allow traffic from pod CIDRs via set lookup
-		if config.FilterIPv4 {
-			tx.Add(&knftables.Rule{
-				Chain: nftFirewallChain,
-				Rule:  knftables.Concat("ip saddr", "@", nftPodCIDRsV4, "accept"),
-			})
-		}
-		if config.FilterIPv6 {
 			tx.Add(&knftables.Rule{
 				Chain: nftFirewallChain,
 				Rule:  knftables.Concat("ip6 saddr", "@", nftPodCIDRsV6, "accept"),
 			})
+			tx.Add(&knftables.Rule{
+				Chain: nftFirewallChain,
+				Rule:  "meta nfproto ipv6 drop",
+			})
 		}
-
-		// Drop everything else
-		tx.Add(&knftables.Rule{
-			Chain: nftFirewallChain,
-			Rule:  "drop",
-		})
 	}
 
 	// --- Masquerade chain ---

--- a/internal/firewall/nftables_test.go
+++ b/internal/firewall/nftables_test.go
@@ -71,7 +71,7 @@ func TestNftablesSyncFilterRules(t *testing.T) {
 	assert.Equal(t, "ct state established,related accept", rules[0].Rule)
 	assert.Equal(t, "meta nfproto ipv6 meta l4proto icmpv6 accept", rules[1].Rule)
 	assert.Contains(t, rules[2].Rule, "ip6 saddr @pod-cidrs-v6 accept")
-	assert.Equal(t, "drop", rules[3].Rule)
+	assert.Equal(t, "meta nfproto ipv6 drop", rules[3].Rule)
 
 	// Verify pod CIDR set was populated
 	v6Set := fake.Table.Sets[nftPodCIDRsV6]


### PR DESCRIPTION
The firewall chain lives in an inet table and sees both IPv4 and IPv6. It previously ended with an unconditional `drop`, so with the default config (FilterIPv6=true, FilterIPv4=false) all forwarded IPv4 pod traffic hit that drop and pod egress / pod-to-pod IPv4 broke.

Gate each family's allow+drop block behind `meta nfproto` so traffic in a family without filtering enabled is left untouched.