### PR TITLE
fix(nftables): evaluate NetworkPolicy before global firewall chain

### DIFF
--- a/internal/firewall/nftables.go
+++ b/internal/firewall/nftables.go
@@ -208,18 +208,26 @@ func (c *nftablesManager) syncRules(ctx context.Context) error {
 				Comment: knftables.PtrTo("offload established flows to fastpath"),
 			})
 		}
-		if enableFilter {
-			tx.Add(&knftables.Rule{
-				Chain:   nftForwardChain,
-				Rule:    "jump " + nftFirewallChain,
-				Comment: knftables.PtrTo("global firewall filtering"),
-			})
-		}
+		// NetworkPolicy must be evaluated before the global firewall chain.
+		// The firewall chain whitelists pod-sourced traffic with a terminal
+		// `accept` verdict (see below), which would stop ruleset evaluation
+		// and bypass NetworkPolicy entirely for all pod-to-pod traffic if it
+		// ran first. The netpol chain instead uses `drop` (terminal) for denied
+		// traffic and falls through for allowed traffic, so anything it permits
+		// continues on to the firewall chain. This matches the iptables backend,
+		// which prepends the netpol jump ahead of the filter jump in FORWARD.
 		if enableNetpol {
 			tx.Add(&knftables.Rule{
 				Chain:   nftForwardChain,
 				Rule:    "jump " + nftNetpolChain,
 				Comment: knftables.PtrTo("NetworkPolicy enforcement"),
+			})
+		}
+		if enableFilter {
+			tx.Add(&knftables.Rule{
+				Chain:   nftForwardChain,
+				Rule:    "jump " + nftFirewallChain,
+				Comment: knftables.PtrTo("global firewall filtering"),
 			})
 		}
 	}

--- a/internal/firewall/nftables_test.go
+++ b/internal/firewall/nftables_test.go
@@ -336,6 +336,68 @@ func TestNftablesDualStack(t *testing.T) {
 	assert.True(t, foundV6Masq, "expected IPv6 masquerade skip rule")
 }
 
+// TestNftablesNetpolBeforeFirewall is a regression test for a NetworkPolicy
+// bypass: when global filtering and NetworkPolicy are both enabled, the forward
+// chain must jump to the netpol chain *before* the firewall chain. The firewall
+// chain whitelists pod-sourced traffic with a terminal `accept`, so if it ran
+// first it would short-circuit ruleset evaluation and skip NetworkPolicy for all
+// pod-to-pod traffic.
+func TestNftablesNetpolBeforeFirewall(t *testing.T) {
+	origFilterIPv4 := config.FilterIPv4
+	origFilterIPv6 := config.FilterIPv6
+	origMasqIPv4 := config.MasqueradeIPv4
+	origMasqIPv6 := config.MasqueradeIPv6
+	origNetpol := config.EnableNetworkPolicy
+	defer func() {
+		config.FilterIPv4 = origFilterIPv4
+		config.FilterIPv6 = origFilterIPv6
+		config.MasqueradeIPv4 = origMasqIPv4
+		config.MasqueradeIPv6 = origMasqIPv6
+		config.EnableNetworkPolicy = origNetpol
+	}()
+
+	config.FilterIPv4 = true
+	config.FilterIPv6 = true
+	config.MasqueradeIPv4 = false
+	config.MasqueradeIPv6 = false
+	config.EnableNetworkPolicy = true
+
+	fake := knftables.NewFake(knftables.InetFamily, nftTable)
+	manager := newTestNftablesManager(fake)
+	manager.currentPodCIDRs = []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/24"),
+	}
+	manager.currentPolicies = []NetworkPolicyRule{
+		{
+			Direction: "ingress",
+			PodIPs:    []netip.Addr{netip.MustParseAddr("10.0.0.5")},
+			Action:    "deny",
+		},
+	}
+
+	err := manager.syncRules(context.Background())
+	require.NoError(t, err)
+
+	fwdChain := fake.Table.Chains[nftForwardChain]
+	require.NotNil(t, fwdChain)
+
+	netpolIdx, firewallIdx := -1, -1
+	for i, r := range fwdChain.Rules {
+		switch r.Rule {
+		case "jump " + nftNetpolChain:
+			netpolIdx = i
+		case "jump " + nftFirewallChain:
+			firewallIdx = i
+		}
+	}
+
+	require.NotEqual(t, -1, netpolIdx, "forward chain must jump to netpol chain")
+	require.NotEqual(t, -1, firewallIdx, "forward chain must jump to firewall chain")
+	assert.Less(t, netpolIdx, firewallIdx,
+		"netpol jump must come before firewall jump, otherwise the firewall chain's "+
+			"terminal accept of pod-sourced traffic bypasses NetworkPolicy")
+}
+
 func TestNftablesNetworkPolicyMultiplePeers(t *testing.T) {
 	origFilterIPv4 := config.FilterIPv4
 	origFilterIPv6 := config.FilterIPv6


### PR DESCRIPTION
## Problem

When **both** global filtering (`FILTER_IPV4`/`FILTER_IPV6`) and NetworkPolicy were enabled on the nftables backend, NetworkPolicy was silently bypassed for all pod-to-pod traffic.

The `forward` base chain jumped to the firewall chain *before* the netpol chain, and the firewall chain whitelists pod-sourced traffic with a terminal `accept`:

```
ip saddr @pod-cidrs-v4 accept   # terminal — stops forward-hook evaluation
```

Once that fired, `jump netpol` was never reached, so no ingress/egress policy applied to pod traffic. This contradicts the documented guarantee (`docs/configuration.md`) that NetworkPolicy is enforced independently of the `FILTER_*` settings. The default manifest ships `FILTER_*=0`, so default installs were unaffected — but the filter feature exists for the public-IPv6-pod scenario, where combining it with NetworkPolicy is natural.

The iptables backend was **not** affected (it uses `RETURN` and prepends netpol ahead of the filter jump in FORWARD).

## Fix

Reorder the forward chain so `jump netpol` precedes `jump firewall`. Netpol's denies are terminal `drop`s and its allows fall through, so permitted traffic still reaches the firewall chain, which continues to drop external→pod traffic. This matches the iptables backend's effective ordering.

## Test

`TestNftablesNetpolBeforeFirewall` enables both features and asserts the jump ordering. Verified it fails on the previous ordering.