### PR TITLE
fix(rbac): patch node annotations instead of full update; scope RBAC to patch

### DIFF
--- a/deploy/ipv6_only.yaml
+++ b/deploy/ipv6_only.yaml
@@ -11,7 +11,7 @@ rules:
       - get
       - list
       - watch
-      - update
+      - patch
   # NetworkPolicy support requires access to pods, namespaces, and networkpolicies
   - apiGroups:
       - ""

--- a/deploy/manifest-metrics.yaml
+++ b/deploy/manifest-metrics.yaml
@@ -11,7 +11,7 @@ rules:
       - get
       - list
       - watch
-      - update
+      - patch
   # NetworkPolicy support requires access to pods, namespaces, and networkpolicies
   - apiGroups:
       - ""

--- a/deploy/manifest.yaml
+++ b/deploy/manifest.yaml
@@ -11,7 +11,7 @@ rules:
       - get
       - list
       - watch
-      - update
+      - patch
   # NetworkPolicy support requires access to pods, namespaces, and networkpolicies
   - apiGroups:
       - ""

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tibordp/wigglenet/internal/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/client-go/util/retry"
 
@@ -197,6 +198,10 @@ func SetupNode(ctx context.Context, nodeClient clientv1.NodeInterface, publicKey
 			return err
 		}
 
+		if node.ObjectMeta.Annotations == nil {
+			node.ObjectMeta.Annotations = map[string]string{}
+		}
+
 		if publicKey != nil {
 			node.ObjectMeta.Annotations[annotation.PublicKeyAnnotation] = base64.StdEncoding.EncodeToString(publicKey)
 		}
@@ -209,7 +214,28 @@ func SetupNode(ctx context.Context, nodeClient clientv1.NodeInterface, publicKey
 			return err
 		}
 
-		_, err = nodeClient.Update(ctx, node, metav1.UpdateOptions{})
+		// Patch only the annotations wigglenet owns rather than PUT-ing the whole
+		// Node object. This lets the ClusterRole grant `patch` instead of `update`
+		// on nodes: `update` lets a token rewrite any field on any node (labels,
+		// taints, …), whereas a JSON merge patch here can only set these keys.
+		annotations := map[string]string{
+			annotation.NodeIpsAnnotation:  node.ObjectMeta.Annotations[annotation.NodeIpsAnnotation],
+			annotation.PodCidrsAnnotation: node.ObjectMeta.Annotations[annotation.PodCidrsAnnotation],
+		}
+		if publicKey != nil {
+			annotations[annotation.PublicKeyAnnotation] = node.ObjectMeta.Annotations[annotation.PublicKeyAnnotation]
+		}
+
+		patch, err := json.Marshal(map[string]any{
+			"metadata": map[string]any{
+				"annotations": annotations,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = nodeClient.Patch(ctx, config.CurrentNodeName, types.MergePatchType, patch, metav1.PatchOptions{})
 		return err
 	})
 }

--- a/internal/controller/setup_test.go
+++ b/internal/controller/setup_test.go
@@ -1,0 +1,120 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tibordp/wigglenet/internal/annotation"
+	"github.com/tibordp/wigglenet/internal/config"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestSetupNodePatchesAnnotations verifies that SetupNode mutates the Node via a
+// merge Patch touching only the wigglenet annotations, and never issues a full
+// Update. This is what allows the ClusterRole to grant `patch` instead of the
+// much broader `update` verb on nodes.
+func TestSetupNodePatchesAnnotations(t *testing.T) {
+	origV4 := config.PodCIDRSourceIPv4
+	origV6 := config.PodCIDRSourceIPv6
+	origIfaces := config.NodeIPInterfaces
+	origNode := config.CurrentNodeName
+	defer func() {
+		config.PodCIDRSourceIPv4 = origV4
+		config.PodCIDRSourceIPv6 = origV6
+		config.NodeIPInterfaces = origIfaces
+		config.CurrentNodeName = origNode
+	}()
+
+	// "none" sources and no interfaces avoid any dependency on host network state.
+	config.PodCIDRSourceIPv4 = config.SourceNone
+	config.PodCIDRSourceIPv6 = config.SourceNone
+	config.NodeIPInterfaces = ""
+	config.CurrentNodeName = "test-node"
+
+	client := fake.NewSimpleClientset(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node",
+			Annotations: map[string]string{"unrelated/keep": "keep-me"},
+		},
+	})
+
+	publicKey := make([]byte, 32)
+	for i := range publicKey {
+		publicKey[i] = byte(i)
+	}
+
+	err := SetupNode(context.Background(), client.CoreV1().Nodes(), publicKey)
+	require.NoError(t, err)
+
+	sawPatch := false
+	for _, a := range client.Actions() {
+		if a.GetResource().Resource != "nodes" {
+			continue
+		}
+		if a.GetVerb() == "update" {
+			t.Fatalf("SetupNode issued an update on nodes; expected patch only")
+		}
+		if a.GetVerb() == "patch" {
+			sawPatch = true
+			payload := map[string]any{}
+			require.NoError(t, json.Unmarshal(a.(k8stesting.PatchAction).GetPatch(), &payload))
+			ann := payload["metadata"].(map[string]any)["annotations"].(map[string]any)
+			assert.Contains(t, ann, annotation.PublicKeyAnnotation)
+			assert.Contains(t, ann, annotation.NodeIpsAnnotation)
+			assert.Contains(t, ann, annotation.PodCidrsAnnotation)
+			assert.NotContains(t, ann, "unrelated/keep", "patch must not touch unrelated annotations")
+		}
+	}
+	assert.True(t, sawPatch, "expected a patch action on nodes")
+
+	// The merge patch should have added the wigglenet annotations while leaving
+	// the pre-existing unrelated annotation intact.
+	node, err := client.CoreV1().Nodes().Get(context.Background(), "test-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "keep-me", node.Annotations["unrelated/keep"])
+	assert.NotEmpty(t, node.Annotations[annotation.PublicKeyAnnotation])
+	assert.Contains(t, node.Annotations, annotation.PodCidrsAnnotation)
+}
+
+// TestSetupNodeOmitsPublicKeyWhenNil checks that firewall-only / native-routing
+// modes (which pass a nil public key) do not write or clear the public-key
+// annotation.
+func TestSetupNodeOmitsPublicKeyWhenNil(t *testing.T) {
+	origV4 := config.PodCIDRSourceIPv4
+	origV6 := config.PodCIDRSourceIPv6
+	origIfaces := config.NodeIPInterfaces
+	origNode := config.CurrentNodeName
+	defer func() {
+		config.PodCIDRSourceIPv4 = origV4
+		config.PodCIDRSourceIPv6 = origV6
+		config.NodeIPInterfaces = origIfaces
+		config.CurrentNodeName = origNode
+	}()
+
+	config.PodCIDRSourceIPv4 = config.SourceNone
+	config.PodCIDRSourceIPv6 = config.SourceNone
+	config.NodeIPInterfaces = ""
+	config.CurrentNodeName = "test-node"
+
+	client := fake.NewSimpleClientset(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+	})
+
+	require.NoError(t, SetupNode(context.Background(), client.CoreV1().Nodes(), nil))
+
+	for _, a := range client.Actions() {
+		if a.GetResource().Resource == "nodes" && a.GetVerb() == "patch" {
+			payload := map[string]any{}
+			require.NoError(t, json.Unmarshal(a.(k8stesting.PatchAction).GetPatch(), &payload))
+			ann := payload["metadata"].(map[string]any)["annotations"].(map[string]any)
+			assert.NotContains(t, ann, annotation.PublicKeyAnnotation,
+				"public-key annotation must not be patched when no key is provided")
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`SetupNode` did `Get` + `Update` on the node, requiring the `update` verb. The ClusterRole granting `update` on `nodes` is bound cluster-wide to a single shared ServiceAccount, so a token from **any** wigglenet pod could rewrite **arbitrary fields on any node** in the cluster — labels, taints, and the `wigglenet/*` peer annotations that drive WireGuard endpoints/keys and routing.

## Fix

- `SetupNode` now sends a JSON merge `Patch` carrying only the wigglenet-owned annotations (`public-key`, `node-ips`, `pod-cidrs`).
- ClusterRole verb narrowed `update` → `patch` in all three deployment manifests.
- Guard against a nil annotations map; the public-key annotation is omitted from the patch when no key is supplied (firewall-only / native-routing modes), so it is never cleared.

## Scope / caveat

This **reduces** the blast radius (a stolen token can no longer rewrite unrelated node fields) but does **not** fully close the trust gap: a `patch` from the shared SA can still target another node's `wigglenet/*` annotations and hijack that peer's WireGuard endpoint/key. Fully fixing that needs per-node identity + an admission policy (NodeRestriction does not apply to a normal SA), which is a larger design change left out of this PR.

## Tests

`TestSetupNodePatchesAnnotations` (asserts Patch-not-Update and that unrelated annotations are preserved) and `TestSetupNodeOmitsPublicKeyWhenNil`.