### PR TITLE
fix: stabilize rule/peer ordering to stop spurious resyncs

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -108,6 +108,12 @@ func (c *controller) applyFirewallRules() error {
 		}
 	}
 
+	// Node listing order is not stable (it comes from the informer cache map),
+	// so sort into a canonical order. Otherwise the firewall manager's
+	// deep-equality check would see a "change" on every node event and rewrite
+	// the whole ruleset needlessly.
+	util.SortPrefixes(podCIDRs)
+
 	if config.EnableMetrics {
 		metrics.PodCIDRsTotal.Set(float64(len(podCIDRs)))
 	}

--- a/internal/networkpolicy/canonical_test.go
+++ b/internal/networkpolicy/canonical_test.go
@@ -1,0 +1,54 @@
+package networkpolicy
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tibordp/wigglenet/internal/firewall"
+)
+
+// TestCanonicalizeRulesDeterministic verifies that two rule sets with identical
+// logical content but different ordering (both of the rules themselves and of
+// the slices within each rule) collapse to deep-equal results after
+// canonicalization. This is what lets the firewall manager's reflect.DeepEqual
+// change detection avoid spurious full ruleset rewrites.
+func TestCanonicalizeRulesDeterministic(t *testing.T) {
+	allowA := firewall.NetworkPolicyRule{
+		Direction:    "ingress",
+		Action:       "allow",
+		PodIPs:       []netip.Addr{netip.MustParseAddr("10.0.0.2"), netip.MustParseAddr("10.0.0.1")},
+		AllowedIPs:   []netip.Addr{netip.MustParseAddr("10.1.0.2"), netip.MustParseAddr("10.1.0.1")},
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("192.168.2.0/24"), netip.MustParsePrefix("192.168.1.0/24")},
+		PortRules:    []firewall.PortRule{{Protocol: "UDP", Port: 53}, {Protocol: "TCP", Port: 80}},
+	}
+	denyA := firewall.NetworkPolicyRule{
+		Direction: "egress",
+		Action:    "deny",
+		PodIPs:    []netip.Addr{netip.MustParseAddr("10.0.0.1")},
+	}
+
+	// Same content, every slice shuffled into a different order.
+	allowB := firewall.NetworkPolicyRule{
+		Direction:    "ingress",
+		Action:       "allow",
+		PodIPs:       []netip.Addr{netip.MustParseAddr("10.0.0.1"), netip.MustParseAddr("10.0.0.2")},
+		AllowedIPs:   []netip.Addr{netip.MustParseAddr("10.1.0.1"), netip.MustParseAddr("10.1.0.2")},
+		AllowedCIDRs: []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24"), netip.MustParsePrefix("192.168.2.0/24")},
+		PortRules:    []firewall.PortRule{{Protocol: "TCP", Port: 80}, {Protocol: "UDP", Port: 53}},
+	}
+	denyB := denyA
+
+	rulesX := []firewall.NetworkPolicyRule{denyA, allowA}
+	rulesY := []firewall.NetworkPolicyRule{allowB, denyB}
+
+	canonicalizeRules(rulesX)
+	canonicalizeRules(rulesY)
+
+	assert.Equal(t, rulesX, rulesY, "logically identical rule sets must canonicalize to equal slices")
+
+	// Canonicalization is idempotent.
+	again := append([]firewall.NetworkPolicyRule(nil), rulesX...)
+	canonicalizeRules(again)
+	assert.Equal(t, rulesX, again)
+}

--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/tibordp/wigglenet/internal/config"
@@ -387,7 +389,71 @@ func (c *controller) generatePolicyRules(ctx context.Context) ([]firewall.Networ
 		})
 	}
 
+	// The rules above are assembled by iterating maps (pods, namespaces, the
+	// affected-pod sets), whose order is randomized in Go. Without canonicalizing,
+	// the generated slice would differ run-to-run for identical cluster state, so
+	// the firewall manager's reflect.DeepEqual change detection would fire on
+	// every pod/namespace event and rewrite the entire ruleset. Sort into a
+	// stable order so equivalent state compares equal.
+	canonicalizeRules(rules)
+
 	return rules, nil
+}
+
+// canonicalizeRules sorts a slice of NetworkPolicyRule (and the slices within
+// each rule) into a deterministic order, so that identical logical state always
+// produces a deep-equal result regardless of map iteration order.
+func canonicalizeRules(rules []firewall.NetworkPolicyRule) {
+	cmpAddr := func(a, b netip.Addr) int { return a.Compare(b) }
+
+	for i := range rules {
+		r := &rules[i]
+		slices.SortFunc(r.PodIPs, cmpAddr)
+		slices.SortFunc(r.AllowedIPs, cmpAddr)
+		util.SortPrefixes(r.AllowedCIDRs)
+		slices.SortFunc(r.PortRules, func(a, b firewall.PortRule) int {
+			if c := strings.Compare(a.Protocol, b.Protocol); c != 0 {
+				return c
+			}
+			if a.Port != b.Port {
+				return a.Port - b.Port
+			}
+			return a.EndPort - b.EndPort
+		})
+	}
+
+	slices.SortFunc(rules, func(a, b firewall.NetworkPolicyRule) int {
+		return strings.Compare(ruleSortKey(a), ruleSortKey(b))
+	})
+}
+
+// ruleSortKey builds a stable string key capturing every field of a rule. It
+// assumes the rule's inner slices have already been sorted.
+func ruleSortKey(r firewall.NetworkPolicyRule) string {
+	var sb strings.Builder
+	sb.WriteString(r.Direction)
+	sb.WriteByte('|')
+	sb.WriteString(r.Action)
+	sb.WriteByte('|')
+	for _, ip := range r.PodIPs {
+		sb.WriteString(ip.String())
+		sb.WriteByte(',')
+	}
+	sb.WriteByte('|')
+	for _, ip := range r.AllowedIPs {
+		sb.WriteString(ip.String())
+		sb.WriteByte(',')
+	}
+	sb.WriteByte('|')
+	for _, c := range r.AllowedCIDRs {
+		sb.WriteString(c.String())
+		sb.WriteByte(',')
+	}
+	sb.WriteByte('|')
+	for _, p := range r.PortRules {
+		fmt.Fprintf(&sb, "%s/%d/%d,", p.Protocol, p.Port, p.EndPort)
+	}
+	return sb.String()
 }
 
 func (c *controller) selectPods(ctx context.Context, namespace string, selector metav1.LabelSelector) []PodInfo {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -59,6 +59,22 @@ func PrefixesToIPNets(prefixes []netip.Prefix) []net.IPNet {
 	return ipnets
 }
 
+// ComparePrefix orders prefixes by network address, then by prefix length. It
+// gives a total order suitable for producing a canonical, deterministic slice.
+func ComparePrefix(a, b netip.Prefix) int {
+	if c := a.Addr().Compare(b.Addr()); c != 0 {
+		return c
+	}
+	return a.Bits() - b.Bits()
+}
+
+// SortPrefixes sorts prefixes in place into the canonical order defined by
+// ComparePrefix. Used to keep firewall/route inputs stable across syncs so that
+// deep-equality change detection does not fire on mere reordering.
+func SortPrefixes(prefixes []netip.Prefix) {
+	slices.SortFunc(prefixes, ComparePrefix)
+}
+
 func SingleHostCIDR(addr netip.Addr) netip.Prefix {
 	bits := 32
 	if addr.Is6() {

--- a/internal/wireguard/wireguard.go
+++ b/internal/wireguard/wireguard.go
@@ -238,20 +238,28 @@ func (c *wireguardManager) reconcileAddresses(logger klog.Logger, addresses []ne
 }
 
 func peerNeedsUpdate(existingPeer *wgtypes.PeerConfig, peer *Peer) bool {
-	if len(existingPeer.AllowedIPs) != len(peer.NodeCIDRs)+len(peer.PodCIDRs) {
+	// Compare AllowedIPs as a set, not positionally: the kernel may return them
+	// in a different order than we configured them, and the desired set is also
+	// assembled from independently-ordered sources. A positional comparison would
+	// report a spurious change on every reconcile and re-issue ConfigureDevice.
+	desired := make(map[netip.Prefix]struct{}, len(peer.PodCIDRs)+len(peer.NodeCIDRs))
+	for _, p := range peer.PodCIDRs {
+		desired[p] = struct{}{}
+	}
+	for _, p := range peer.NodeCIDRs {
+		desired[p] = struct{}{}
+	}
+
+	if len(existingPeer.AllowedIPs) != len(desired) {
 		return true
 	}
 
-	for i := range peer.PodCIDRs {
-		existingPrefix, ok := util.PrefixFromIPNet(existingPeer.AllowedIPs[i])
-		if !ok || existingPrefix != peer.PodCIDRs[i] {
+	for _, allowedIP := range existingPeer.AllowedIPs {
+		existingPrefix, ok := util.PrefixFromIPNet(allowedIP)
+		if !ok {
 			return true
 		}
-	}
-
-	for i := range peer.NodeCIDRs {
-		existingPrefix, ok := util.PrefixFromIPNet(existingPeer.AllowedIPs[len(peer.PodCIDRs)+i])
-		if !ok || existingPrefix != peer.NodeCIDRs[i] {
+		if _, found := desired[existingPrefix]; !found {
 			return true
 		}
 	}

--- a/internal/wireguard/wireguard_test.go
+++ b/internal/wireguard/wireguard_test.go
@@ -56,6 +56,42 @@ func TestCreateChangesetNoChange(t *testing.T) {
 	assert.Len(t, actual, 0)
 }
 
+func TestCreateChangesetNoChangeReorderedAllowedIPs(t *testing.T) {
+	// The existing peer carries the same AllowedIPs as desired, but in a
+	// different order and split differently across the Pod/Node CIDR buckets.
+	// peerNeedsUpdate compares them as a set, so this must produce no changeset;
+	// a positional comparison would have reported a spurious update.
+	existingPeers := []wgtypes.Peer{
+		{
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+			Endpoint:  &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 24601},
+			AllowedIPs: []net.IPNet{
+				parseCIDR("2001:db8:0:1::/64"),
+				parseCIDR("192.168.0.5/32"),
+				parseCIDR("192.168.0.0/24"),
+			},
+		},
+	}
+
+	desiredPeers := []Peer{
+		{
+			Endpoint: netip.MustParseAddr("192.168.0.1"),
+			PodCIDRs: []netip.Prefix{
+				parsePrefix("192.168.0.0/24"),
+				parsePrefix("2001:db8:0:1::/64"),
+			},
+			NodeCIDRs: []netip.Prefix{
+				parsePrefix("192.168.0.5/32"),
+			},
+			PublicKey: parseKey("2H+7wEq3SZOfPjNuoWatIUZnHIeR6SEiv5BiJmSJqEg="),
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	actual := createPeerChangeset(logger, existingPeers, desiredPeers)
+	assert.Len(t, actual, 0, "reordered but identical AllowedIPs should not trigger an update")
+}
+
 func TestCreateChangesetAdd(t *testing.T) {
 	existingPeers := []wgtypes.Peer{
 		{


### PR DESCRIPTION
## Problem

Generated state was derived from Go map iteration (pods, namespaces, node list), so identical cluster state produced differently-ordered slices on each pass. The firewall manager and WireGuard reconciler detect change via `reflect.DeepEqual` / positional comparison, so this churned the **entire** nftables/iptables ruleset and re-issued WireGuard `ConfigureDevice` on essentially every pod/node/namespace event.

## Fix

- **networkpolicy**: canonicalize generated rules (sort the rule slice and the IP/CIDR/port slices within each rule) before handing them to the firewall manager.
- **controller**: sort pod CIDRs before sending them to the firewall manager.
- **wireguard**: compare peer `AllowedIPs` as a set rather than positionally, since the kernel may return them reordered.
- **util**: add `ComparePrefix` / `SortPrefixes` helpers.

No behavioral change to the actual rules/peers — only ordering/comparison stability.

## Tests

`TestCanonicalizeRulesDeterministic` (order-insensitive + idempotent) and `TestCreateChangesetNoChangeReorderedAllowedIPs` (reordered-but-identical AllowedIPs produce no changeset; verified it fails without the fix).