### PR TITLE
refactor: use SharedInformerFactory + listers in controllers

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -19,11 +19,13 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
-	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -33,46 +35,48 @@ type Controller interface {
 }
 
 type controller struct {
-	indexer        cache.Indexer
+	factory        informers.SharedInformerFactory
+	nodeLister     listersv1.NodeLister
 	queue          workqueue.TypedRateLimitingInterface[string]
-	informer       cache.Controller
 	wireguard      wireguard.Manager
 	cniwriter      cni.CNIConfigWriter
 	podCIDRUpdates chan []netip.Prefix
 }
 
-func NewController(clientset kubernetes.Interface, wireguardManager wireguard.Manager, cniwriter cni.CNIConfigWriter, podCIDRUpdates chan []netip.Prefix) *controller {
-	nodeListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "nodes", v1.NamespaceAll, fields.Everything())
+func NewController(clientset kubernetes.Interface, wireguardManager wireguard.Manager, cniwriter cni.CNIConfigWriter, podCIDRUpdates chan []netip.Prefix) (*controller, error) {
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, informers.WithTransform(util.StripManagedFields))
+	nodes := factory.Core().V1().Nodes()
+
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
-	indexer, informer := cache.NewTransformingIndexerInformer(nodeListWatcher, &v1.Node{}, 0, cache.ResourceEventHandlerFuncs{
+
+	if _, err := nodes.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(obj)
-			if err == nil {
+			if key, err := cache.MetaNamespaceKeyFunc(obj); err == nil {
 				queue.Add(key)
 			}
 		},
-		UpdateFunc: func(old interface{}, new interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(new)
-			if err == nil {
+		UpdateFunc: func(_, newObj interface{}) {
+			if key, err := cache.MetaNamespaceKeyFunc(newObj); err == nil {
 				queue.Add(key)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			if err == nil {
+			if key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err == nil {
 				queue.Add(key)
 			}
 		},
-	}, cache.Indexers{}, util.StripManagedFields)
+	}); err != nil {
+		return nil, fmt.Errorf("registering node event handler: %w", err)
+	}
 
 	return &controller{
-		informer:       informer,
-		indexer:        indexer,
+		factory:        factory,
+		nodeLister:     nodes.Lister(),
 		queue:          queue,
 		wireguard:      wireguardManager,
 		cniwriter:      cniwriter,
 		podCIDRUpdates: podCIDRUpdates,
-	}
+	}, nil
 }
 
 // processChanges gets called on any change to a node object as well as additions and removals.
@@ -100,12 +104,14 @@ func (c *controller) processChanges(ctx context.Context, key string) error {
 // applyFirewallRules calculates the new pod network and sends it to the iptables sync
 // goroutine so that pod traffic can be appropriately filtered and masqueraded.
 func (c *controller) applyFirewallRules() error {
-	podCIDRs := make([]netip.Prefix, 0)
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
 
-	for _, v := range c.indexer.List() {
-		if node, ok := v.(*v1.Node); ok {
-			podCIDRs = append(podCIDRs, util.GetPodCIDRsFromAnnotation(node)...)
-		}
+	podCIDRs := make([]netip.Prefix, 0)
+	for _, node := range nodes {
+		podCIDRs = append(podCIDRs, util.GetPodCIDRsFromAnnotation(node)...)
 	}
 
 	// Node listing order is not stable (it comes from the informer cache map),
@@ -128,19 +134,21 @@ func (c *controller) applyFirewallRules() error {
 func (c *controller) applyWireguardConfiguration(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
 	peers := make([]wireguard.Peer, 0)
 	localAddresses := make([]netip.Addr, 0)
 
-	for _, v := range c.indexer.List() {
-		if node, ok := v.(*v1.Node); ok {
-			if node.Name == config.CurrentNodeName {
-				podCIDRs := util.GetPodCIDRsFromAnnotation(node)
-				localAddresses = util.GetPodNetworkLocalAddresses(podCIDRs)
-			} else {
-				peer := makePeer(ctx, node)
-				if peer != nil {
-					peers = append(peers, *peer)
-				}
+	for _, node := range nodes {
+		if node.Name == config.CurrentNodeName {
+			podCIDRs := util.GetPodCIDRsFromAnnotation(node)
+			localAddresses = util.GetPodNetworkLocalAddresses(podCIDRs)
+		} else {
+			if peer := makePeer(ctx, node); peer != nil {
+				peers = append(peers, *peer)
 			}
 		}
 	}
@@ -158,23 +166,23 @@ func (c *controller) applyWireguardConfiguration(ctx context.Context) error {
 // e.g. if another address family is added to an existing cluster.
 func (c *controller) ensureCNI(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
-	item, exists, _ := c.indexer.GetByKey(config.CurrentNodeName)
-	if node, ok := item.(*v1.Node); exists && ok {
-		podCIDRs := util.GetPodCIDRsFromAnnotation(node)
-
-		if len(podCIDRs) == 0 {
-			logger.Info("node does not have PodCIDRs assigned yet", "node", node.Name)
-			return nil
-		}
-
-		config := cni.CNIConfig{
-			PodCIDRs: podCIDRs,
-		}
-
-		return c.cniwriter.WriteCNIConfig(ctx, config, logger)
+	node, err := c.nodeLister.Get(config.CurrentNodeName)
+	if err != nil {
+		// Node not yet observed in the cache; nothing to write.
+		return nil
 	}
 
-	return nil
+	podCIDRs := util.GetPodCIDRsFromAnnotation(node)
+	if len(podCIDRs) == 0 {
+		logger.Info("node does not have PodCIDRs assigned yet", "node", node.Name)
+		return nil
+	}
+
+	config := cni.CNIConfig{
+		PodCIDRs: podCIDRs,
+	}
+
+	return c.cniwriter.WriteCNIConfig(ctx, config, logger)
 }
 
 func getNodeAddresses(ctx context.Context, node *v1.Node) ([]netip.Addr, error) {
@@ -265,17 +273,17 @@ func (c *controller) Run(ctx context.Context) {
 	defer c.queue.ShutDown()
 	logger.Info("starting controller")
 
-	go c.informer.Run(ctx.Done())
+	c.factory.StartWithContext(ctx)
 
 	// Wait for all involved caches to be synced, before processing items from the queue is started
-	if !cache.WaitForCacheSync(ctx.Done(), c.informer.HasSynced) {
-		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+	if err := c.factory.WaitForCacheSyncWithContext(ctx).AsError(); err != nil {
+		runtime.HandleErrorWithContext(ctx, err, "timed out waiting for caches to sync")
 		return
 	}
 
 	// After we have all the nodes in cache, sync the routing state
 	if err := c.applyWireguardConfiguration(ctx); err != nil {
-		runtime.HandleError(err)
+		runtime.HandleErrorWithContext(ctx, err, "failed initial wireguard configuration")
 	}
 
 	go wait.UntilWithContext(ctx, c.runWorker, time.Second)

--- a/internal/networkpolicy/informer_test.go
+++ b/internal/networkpolicy/informer_test.go
@@ -1,0 +1,76 @@
+package networkpolicy
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tibordp/wigglenet/internal/firewall"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2/ktesting"
+)
+
+// TestControllerEndToEndWithFakeClientset drives the controller through its real
+// constructor and Run loop against a fake clientset, exercising the
+// SharedInformerFactory wiring, event handlers, and the lister-backed
+// updatePodsMap / generatePolicyRules path end to end.
+func TestControllerEndToEndWithFakeClientset(t *testing.T) {
+	_, baseCtx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(baseCtx)
+	defer cancel()
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default", Labels: map[string]string{"app": "web"}},
+		Status: v1.PodStatus{
+			Phase:  v1.PodRunning,
+			PodIPs: []v1.PodIP{{IP: "10.0.0.1"}},
+			PodIP:  "10.0.0.1",
+		},
+	}
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	// Ingress policy selecting app=web with no rules -> default-deny ingress.
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "deny-web", Namespace: "default"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+
+	client := fake.NewSimpleClientset(pod, ns, np)
+	updates := make(chan []firewall.NetworkPolicyRule, 8)
+
+	ctrl, err := NewController(client, updates)
+	require.NoError(t, err)
+
+	go ctrl.Run(ctx)
+
+	select {
+	case rules := <-updates:
+		var denies []firewall.NetworkPolicyRule
+		for _, r := range rules {
+			if r.Action == "deny" && r.Direction == "ingress" {
+				denies = append(denies, r)
+			}
+		}
+		require.NotEmpty(t, denies, "expected a default-deny ingress rule for the selected pod")
+
+		found := false
+		for _, r := range denies {
+			for _, ip := range r.PodIPs {
+				if ip == netip.MustParseAddr("10.0.0.1") {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "expected deny rule to cover pod IP 10.0.0.1")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the controller to emit policy rules")
+	}
+}

--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -18,12 +18,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -47,20 +49,12 @@ type PodInfo struct {
 }
 
 type controller struct {
-	clientset     kubernetes.Interface
 	policyUpdates chan []firewall.NetworkPolicyRule
 
-	// NetworkPolicy informer
-	netpolIndexer  cache.Indexer
-	netpolInformer cache.Controller
-
-	// Pod informer
-	podIndexer  cache.Indexer
-	podInformer cache.Controller
-
-	// Namespace informer
-	nsIndexer  cache.Indexer
-	nsInformer cache.Controller
+	factory      informers.SharedInformerFactory
+	netpolLister networkinglisters.NetworkPolicyLister
+	podLister    corelisters.PodLister
+	nsLister     corelisters.NamespaceLister
 
 	queue workqueue.TypedRateLimitingInterface[string]
 
@@ -69,86 +63,48 @@ type controller struct {
 	namespaces map[string]map[string]string // namespace -> labels
 }
 
-func NewController(clientset kubernetes.Interface, policyUpdates chan []firewall.NetworkPolicyRule) Controller {
-	// NetworkPolicy informer
-	netpolListWatcher := cache.NewListWatchFromClient(
-		clientset.NetworkingV1().RESTClient(),
-		"networkpolicies",
-		metav1.NamespaceAll,
-		fields.Everything(),
-	)
+func NewController(clientset kubernetes.Interface, policyUpdates chan []firewall.NetworkPolicyRule) (Controller, error) {
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, informers.WithTransform(util.StripManagedFields))
 
-	// Pod informer
-	podListWatcher := cache.NewListWatchFromClient(
-		clientset.CoreV1().RESTClient(),
-		"pods",
-		metav1.NamespaceAll,
-		fields.Everything(),
-	)
-
-	// Namespace informer
-	nsListWatcher := cache.NewListWatchFromClient(
-		clientset.CoreV1().RESTClient(),
-		"namespaces",
-		metav1.NamespaceAll,
-		fields.Everything(),
-	)
+	netpols := factory.Networking().V1().NetworkPolicies()
+	pods := factory.Core().V1().Pods()
+	namespaces := factory.Core().V1().Namespaces()
 
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 
-	// Create indexers and informers
-	netpolIndexer, netpolInformer := cache.NewTransformingIndexerInformer(
-		netpolListWatcher,
-		&networkingv1.NetworkPolicy{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { queue.Add("networkpolicy") },
-			UpdateFunc: func(old, new interface{}) { queue.Add("networkpolicy") },
-			DeleteFunc: func(obj interface{}) { queue.Add("networkpolicy") },
-		},
-		cache.Indexers{},
-		util.StripManagedFields,
-	)
+	// Every object change in any of the watched resources triggers a full
+	// resync, so the handlers collapse onto one queue key per resource type.
+	enqueueOn := func(key string) cache.ResourceEventHandlerFuncs {
+		return cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(interface{}) { queue.Add(key) },
+			UpdateFunc: func(interface{}, interface{}) { queue.Add(key) },
+			DeleteFunc: func(interface{}) { queue.Add(key) },
+		}
+	}
 
-	podIndexer, podInformer := cache.NewTransformingIndexerInformer(
-		podListWatcher,
-		&v1.Pod{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { queue.Add("pod") },
-			UpdateFunc: func(old, new interface{}) { queue.Add("pod") },
-			DeleteFunc: func(obj interface{}) { queue.Add("pod") },
-		},
-		cache.Indexers{},
-		util.StripManagedFields,
-	)
-
-	nsIndexer, nsInformer := cache.NewTransformingIndexerInformer(
-		nsListWatcher,
-		&v1.Namespace{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { queue.Add("namespace") },
-			UpdateFunc: func(old, new interface{}) { queue.Add("namespace") },
-			DeleteFunc: func(obj interface{}) { queue.Add("namespace") },
-		},
-		cache.Indexers{},
-		util.StripManagedFields,
-	)
+	for _, reg := range []struct {
+		informer cache.SharedIndexInformer
+		key      string
+	}{
+		{netpols.Informer(), "networkpolicy"},
+		{pods.Informer(), "pod"},
+		{namespaces.Informer(), "namespace"},
+	} {
+		if _, err := reg.informer.AddEventHandler(enqueueOn(reg.key)); err != nil {
+			return nil, fmt.Errorf("registering %s event handler: %w", reg.key, err)
+		}
+	}
 
 	return &controller{
-		clientset:      clientset,
-		policyUpdates:  policyUpdates,
-		netpolIndexer:  netpolIndexer,
-		netpolInformer: netpolInformer,
-		podIndexer:     podIndexer,
-		podInformer:    podInformer,
-		nsIndexer:      nsIndexer,
-		nsInformer:     nsInformer,
-		queue:          queue,
-		pods:           make(map[netip.Addr]PodInfo),
-		namespaces:     make(map[string]map[string]string),
-	}
+		policyUpdates: policyUpdates,
+		factory:       factory,
+		netpolLister:  netpols.Lister(),
+		podLister:     pods.Lister(),
+		nsLister:      namespaces.Lister(),
+		queue:         queue,
+		pods:          make(map[netip.Addr]PodInfo),
+		namespaces:    make(map[string]map[string]string),
+	}, nil
 }
 
 func (c *controller) Run(ctx context.Context) {
@@ -158,22 +114,16 @@ func (c *controller) Run(ctx context.Context) {
 
 	logger.Info("starting NetworkPolicy controller")
 
-	// Start informers
-	go c.netpolInformer.Run(ctx.Done())
-	go c.podInformer.Run(ctx.Done())
-	go c.nsInformer.Run(ctx.Done())
-
-	// Wait for caches to sync
-	if !cache.WaitForCacheSync(ctx.Done(),
-		c.netpolInformer.HasSynced,
-		c.podInformer.HasSynced,
-		c.nsInformer.HasSynced) {
-		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+	c.factory.StartWithContext(ctx)
+	if err := c.factory.WaitForCacheSyncWithContext(ctx).AsError(); err != nil {
+		runtime.HandleErrorWithContext(ctx, err, "timed out waiting for caches to sync")
 		return
 	}
 
 	// Initial sync
-	c.syncState(ctx)
+	if err := c.syncState(ctx); err != nil {
+		runtime.HandleErrorWithContext(ctx, err, "initial NetworkPolicy sync failed")
+	}
 
 	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	<-ctx.Done()
@@ -205,11 +155,13 @@ func (c *controller) processNextItem(ctx context.Context) bool {
 }
 
 func (c *controller) syncState(ctx context.Context) error {
-	// Update pods map
-	c.updatePodsMap()
-
-	// Update namespaces map
-	c.updateNamespacesMap()
+	// Refresh the pod and namespace lookup maps from the informer caches.
+	if err := c.updatePodsMap(); err != nil {
+		return err
+	}
+	if err := c.updateNamespacesMap(); err != nil {
+		return err
+	}
 
 	// Generate NetworkPolicy rules
 	policyRules, err := c.generatePolicyRules(ctx)
@@ -237,53 +189,57 @@ func (c *controller) syncState(ctx context.Context) error {
 	return nil
 }
 
-func (c *controller) updatePodsMap() {
+func (c *controller) updatePodsMap() error {
+	podList, err := c.podLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
 	newPods := make(map[netip.Addr]PodInfo)
+	for _, pod := range podList {
+		if pod.Status.Phase != v1.PodRunning {
+			continue
+		}
 
-	for _, obj := range c.podIndexer.List() {
-		if pod, ok := obj.(*v1.Pod); ok {
-			if pod.Status.Phase == v1.PodRunning {
-				// Collect container ports for named-port resolution
-				var cPorts []ContainerPort
-				for _, container := range pod.Spec.Containers {
-					for _, cp := range container.Ports {
-						proto := "TCP"
-						if cp.Protocol != "" {
-							proto = string(cp.Protocol)
-						}
-						cPorts = append(cPorts, ContainerPort{
-							Name:          cp.Name,
-							ContainerPort: cp.ContainerPort,
-							Protocol:      proto,
-						})
+		// Collect container ports for named-port resolution
+		var cPorts []ContainerPort
+		for _, container := range pod.Spec.Containers {
+			for _, cp := range container.Ports {
+				proto := "TCP"
+				if cp.Protocol != "" {
+					proto = string(cp.Protocol)
+				}
+				cPorts = append(cPorts, ContainerPort{
+					Name:          cp.Name,
+					ContainerPort: cp.ContainerPort,
+					Protocol:      proto,
+				})
+			}
+		}
+
+		// Handle dual-stack: read all pod IPs from status.podIPs
+		for _, podIPStatus := range pod.Status.PodIPs {
+			if podIPStatus.IP != "" {
+				if addr, err := netip.ParseAddr(podIPStatus.IP); err == nil {
+					newPods[addr] = PodInfo{
+						IP:             addr,
+						Namespace:      pod.Namespace,
+						Labels:         pod.Labels,
+						ContainerPorts: cPorts,
 					}
 				}
+			}
+		}
 
-				// Handle dual-stack: read all pod IPs from status.podIPs
-				for _, podIPStatus := range pod.Status.PodIPs {
-					if podIPStatus.IP != "" {
-						if addr, err := netip.ParseAddr(podIPStatus.IP); err == nil {
-							newPods[addr] = PodInfo{
-								IP:             addr,
-								Namespace:      pod.Namespace,
-								Labels:         pod.Labels,
-								ContainerPorts: cPorts,
-							}
-						}
-					}
-				}
-
-				// Fallback to status.podIP for compatibility
-				if pod.Status.PodIP != "" {
-					if addr, err := netip.ParseAddr(pod.Status.PodIP); err == nil {
-						if _, exists := newPods[addr]; !exists {
-							newPods[addr] = PodInfo{
-								IP:             addr,
-								Namespace:      pod.Namespace,
-								Labels:         pod.Labels,
-								ContainerPorts: cPorts,
-							}
-						}
+		// Fallback to status.podIP for compatibility
+		if pod.Status.PodIP != "" {
+			if addr, err := netip.ParseAddr(pod.Status.PodIP); err == nil {
+				if _, exists := newPods[addr]; !exists {
+					newPods[addr] = PodInfo{
+						IP:             addr,
+						Namespace:      pod.Namespace,
+						Labels:         pod.Labels,
+						ContainerPorts: cPorts,
 					}
 				}
 			}
@@ -291,33 +247,37 @@ func (c *controller) updatePodsMap() {
 	}
 
 	c.pods = newPods
+	return nil
 }
 
-func (c *controller) updateNamespacesMap() {
-	newNamespaces := make(map[string]map[string]string)
+func (c *controller) updateNamespacesMap() error {
+	nsList, err := c.nsLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
 
-	for _, obj := range c.nsIndexer.List() {
-		if ns, ok := obj.(*v1.Namespace); ok {
-			newNamespaces[ns.Name] = ns.Labels
-		}
+	newNamespaces := make(map[string]map[string]string)
+	for _, ns := range nsList {
+		newNamespaces[ns.Name] = ns.Labels
 	}
 
 	c.namespaces = newNamespaces
+	return nil
 }
 
 func (c *controller) generatePolicyRules(ctx context.Context) ([]firewall.NetworkPolicyRule, error) {
+	netpols, err := c.netpolLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
 	var rules []firewall.NetworkPolicyRule
 
 	// Track which pods are affected by policies (by direction)
 	affectedPodsIngress := make(map[netip.Addr]bool) // podIP -> true
 	affectedPodsEgress := make(map[netip.Addr]bool)  // podIP -> true
 
-	for _, obj := range c.netpolIndexer.List() {
-		netpol, ok := obj.(*networkingv1.NetworkPolicy)
-		if !ok {
-			continue
-		}
-
+	for _, netpol := range netpols {
 		// Find pods that this policy applies to
 		selectedPods := c.selectPods(ctx, netpol.Namespace, netpol.Spec.PodSelector)
 

--- a/internal/networkpolicy/networkpolicy_test.go
+++ b/internal/networkpolicy/networkpolicy_test.go
@@ -10,6 +10,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2/ktesting"
 )
@@ -249,45 +250,43 @@ func TestGeneratePolicyRulesWithDefaultDeny(t *testing.T) {
 		namespaces: map[string]map[string]string{
 			"default": {"env": "prod"},
 		},
-		netpolIndexer: &fakeIndexer{
-			items: []interface{}{
-				&networkingv1.NetworkPolicy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "web-netpol",
-						Namespace: "default",
+		netpolLister: newNetpolLister(
+			&networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-netpol",
+					Namespace: "default",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "web"},
 					},
-					Spec: networkingv1.NetworkPolicySpec{
-						PodSelector: metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "web"},
-						},
-						PolicyTypes: []networkingv1.PolicyType{
-							networkingv1.PolicyTypeIngress,
-							networkingv1.PolicyTypeEgress,
-						},
-						Ingress: []networkingv1.NetworkPolicyIngressRule{
-							{
-								From: []networkingv1.NetworkPolicyPeer{
-									{
-										PodSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{"app": "backend"},
-										},
-									},
-								},
-								Ports: []networkingv1.NetworkPolicyPort{
-									{
-										Port:     &intstr.IntOrString{IntVal: 80},
-										Protocol: &[]v1.Protocol{v1.ProtocolTCP}[0],
+					PolicyTypes: []networkingv1.PolicyType{
+						networkingv1.PolicyTypeIngress,
+						networkingv1.PolicyTypeEgress,
+					},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{
+						{
+							From: []networkingv1.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app": "backend"},
 									},
 								},
 							},
+							Ports: []networkingv1.NetworkPolicyPort{
+								{
+									Port:     &intstr.IntOrString{IntVal: 80},
+									Protocol: &[]v1.Protocol{v1.ProtocolTCP}[0],
+								},
+							},
 						},
-						Egress: []networkingv1.NetworkPolicyEgressRule{
-							{
-								To: []networkingv1.NetworkPolicyPeer{
-									{
-										IPBlock: &networkingv1.IPBlock{
-											CIDR: "0.0.0.0/0",
-										},
+					},
+					Egress: []networkingv1.NetworkPolicyEgressRule{
+						{
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									IPBlock: &networkingv1.IPBlock{
+										CIDR: "0.0.0.0/0",
 									},
 								},
 							},
@@ -295,7 +294,7 @@ func TestGeneratePolicyRulesWithDefaultDeny(t *testing.T) {
 					},
 				},
 			},
-		},
+		),
 	}
 
 	rules, err := c.generatePolicyRules(ctx)
@@ -457,36 +456,14 @@ func TestProcessNetworkPolicyPeerIPBlockExcept(t *testing.T) {
 	assert.False(t, found5, "10.0.5.1 should NOT be in the allowed CIDRs (excepted)")
 }
 
-// fakeIndexer implements cache.Indexer interface for testing
-type fakeIndexer struct {
-	items []interface{}
+// newNetpolLister builds a real NetworkPolicyLister backed by an in-memory
+// indexer, for tests that exercise generatePolicyRules.
+func newNetpolLister(netpols ...*networkingv1.NetworkPolicy) networkinglisters.NetworkPolicyLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, np := range netpols {
+		_ = indexer.Add(np)
+	}
+	return networkinglisters.NewNetworkPolicyLister(indexer)
 }
-
-func (f *fakeIndexer) List() []interface{} {
-	return f.items
-}
-
-func (f *fakeIndexer) Add(obj interface{}) error    { return nil }
-func (f *fakeIndexer) Update(obj interface{}) error { return nil }
-func (f *fakeIndexer) Delete(obj interface{}) error { return nil }
-func (f *fakeIndexer) ListKeys() []string           { return nil }
-func (f *fakeIndexer) Get(obj interface{}) (item interface{}, exists bool, err error) {
-	return nil, false, nil
-}
-func (f *fakeIndexer) GetByKey(key string) (item interface{}, exists bool, err error) {
-	return nil, false, nil
-}
-func (f *fakeIndexer) Replace([]interface{}, string) error  { return nil }
-func (f *fakeIndexer) Resync() error                        { return nil }
-func (f *fakeIndexer) Bookmark(rv string)                   {}
-func (f *fakeIndexer) LastStoreSyncResourceVersion() string { return "" }
-func (f *fakeIndexer) Index(indexName string, obj interface{}) ([]interface{}, error) {
-	return nil, nil
-}
-func (f *fakeIndexer) IndexKeys(indexName, indexKey string) ([]string, error) { return nil, nil }
-func (f *fakeIndexer) ListIndexFuncValues(indexName string) []string          { return nil }
-func (f *fakeIndexer) ByIndex(indexName, indexKey string) ([]interface{}, error) {
-	return nil, nil
-}
-func (f *fakeIndexer) GetIndexers() cache.Indexers                  { return nil }
-func (f *fakeIndexer) AddIndexers(newIndexers cache.Indexers) error { return nil }

--- a/internal/wigglenet.go
+++ b/internal/wigglenet.go
@@ -44,10 +44,16 @@ func New(ctx context.Context) (Wigglenet, error) {
 	var publicKey []byte
 
 	if config.FirewallOnly {
-		ctrl = controller.NewController(clientset, nil, nil, podCIDRUpdates)
+		ctrl, err = controller.NewController(clientset, nil, nil, podCIDRUpdates)
+		if err != nil {
+			return nil, err
+		}
 	} else if config.NativeRouting {
 		cniwriter := cni.NewCNIConfigWriter()
-		ctrl = controller.NewController(clientset, nil, cniwriter, podCIDRUpdates)
+		ctrl, err = controller.NewController(clientset, nil, cniwriter, podCIDRUpdates)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		wg, err := wireguard.NewManager(ctx)
 		if err != nil {
@@ -55,7 +61,10 @@ func New(ctx context.Context) (Wigglenet, error) {
 		}
 
 		cniwriter := cni.NewCNIConfigWriter()
-		ctrl = controller.NewController(clientset, wg, cniwriter, podCIDRUpdates)
+		ctrl, err = controller.NewController(clientset, wg, cniwriter, podCIDRUpdates)
+		if err != nil {
+			return nil, err
+		}
 		publicKey = wg.PublicKey()
 
 		if config.EnableMetrics {
@@ -66,7 +75,10 @@ func New(ctx context.Context) (Wigglenet, error) {
 	// Create NetworkPolicy controller if enabled
 	var netpolController networkpolicy.Controller
 	if config.EnableNetworkPolicy {
-		netpolController = networkpolicy.NewController(clientset, policyUpdates)
+		netpolController, err = networkpolicy.NewController(clientset, policyUpdates)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if config.EnableMetrics {


### PR DESCRIPTION
Modernizes the controller boilerplate to the idiomatic client-go pattern. No behavior change — same level-driven full resync on every watched-object event.

## What changed

Both the node controller and the NetworkPolicy controller drop the low-level `cache.NewListWatchFromClient` + `NewTransformingIndexerInformer` plumbing in favor of a `SharedInformerFactory` and typed listers.

- One `factory.StartWithContext` / `WaitForCacheSyncWithContext` per controller instead of starting and syncing each informer by hand.
- Typed listers (`NodeLister`, `PodLister`, `NamespaceLister`, `NetworkPolicyLister`) replace untyped `Indexer.List()`/`GetByKey()` + type assertions.
- Managed-fields transform preserved via `informers.WithTransform`.
- `AddEventHandler` errors are now checked, so both constructors return an `error`; `wigglenet.New` propagates it.
- Standardize on the contextual `runtime.HandleErrorWithContext` and the context-aware informer start/sync APIs.

## Tests

- NetworkPolicy unit test's hand-written `fakeIndexer` replaced with a real lister over an in-memory indexer.
- New end-to-end test drives the controller through `NewController` + `Run` against a fake clientset, exercising the factory wiring, event handlers, and lister-backed `updatePodsMap`/`generatePolicyRules` path.