### PR TITLE
fix: report the real build version in build_info metric

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,3 +56,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Stamp the build version into the wigglenet_build_info metric. Uses the
+          # same version metadata-action derives for the image tag (the semver for
+          # v* tags, the branch name for master, pr-N for pull requests).
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,13 @@ RUN go mod download
 COPY cmd cmd
 COPY internal internal
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o \
-    /wigglenetd ./cmd/wigglenet
+# Version reported via the wigglenet_build_info metric. Override with
+# `docker build --build-arg VERSION=v0.6.1 ...` (the Makefile derives it from git).
+ARG VERSION=dev
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a \
+    -ldflags "-X github.com/tibordp/wigglenet/internal.Version=${VERSION}" \
+    -o /wigglenetd ./cmd/wigglenet
 
 FROM alpine:3.22
 # Install nftables 1.0.x from Alpine 3.20 rather than the default 1.1.x.

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ kind-v4-only:
 kind-v6-singlestack:
 	kind create cluster --config testing/cluster_v6_singlestack.yaml
 
+# Version stamped into the wigglenet_build_info metric (derived from git).
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
 image:
-	docker build -t wigglenet .
+	docker build --build-arg VERSION=$(VERSION) -t wigglenet .
 	kind load docker-image wigglenet
 
 # Patch manifest to use local Docker image instead of one from Dockerhub

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mdlayher/genetlink v1.4.0 // indirect
 	github.com/mdlayher/netlink v1.11.2 // indirect
 	github.com/mdlayher/socket v0.6.1 // indirect

--- a/internal/metrics/buildinfo_test.go
+++ b/internal/metrics/buildinfo_test.go
@@ -1,0 +1,25 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetBuildInfo verifies the version and backend reach the build_info metric
+// as labels (regression guard against the previously hardcoded version string).
+func TestSetBuildInfo(t *testing.T) {
+	BuildInfo.Reset()
+	SetBuildInfo("v1.2.3", "nftables")
+
+	expected := `
+# HELP wigglenet_build_info Build information. Always 1.
+# TYPE wigglenet_build_info gauge
+wigglenet_build_info{firewall_backend="nftables",version="v1.2.3"} 1
+`
+	require.NoError(t, testutil.CollectAndCompare(BuildInfo, strings.NewReader(expected), "wigglenet_build_info"))
+	assert.Equal(t, 1, testutil.CollectAndCount(BuildInfo))
+}

--- a/internal/wigglenet.go
+++ b/internal/wigglenet.go
@@ -17,6 +17,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// Version is the build version reported via the wigglenet_build_info metric.
+// It is overridden at build time with -ldflags "-X github.com/tibordp/wigglenet/internal.Version=<version>".
+var Version = "dev"
+
 type Wigglenet interface {
 	Run(ctx context.Context)
 }
@@ -70,7 +74,7 @@ func New(ctx context.Context) (Wigglenet, error) {
 	}
 
 	if config.EnableMetrics {
-		metrics.SetBuildInfo("0.5.0", string(config.FirewallBackendMode))
+		metrics.SetBuildInfo(Version, string(config.FirewallBackendMode))
 	}
 
 	// Populate the node annotations


### PR DESCRIPTION
`metrics.SetBuildInfo` was called with a hardcoded `"0.5.0"` while the project was at v0.6.1, so `wigglenet_build_info` always reported a stale version.

## What changed

Introduce `internal.Version` (default `"dev"`), overridable at build time via `-ldflags "-X github.com/tibordp/wigglenet/internal.Version=<v>"`, threaded through all build paths:

- **`.github/workflows/docker.yml`** — the workflow that builds & pushes the real `ghcr.io` image passes `VERSION=${{ steps.meta.outputs.version }}` as a build-arg, so `build_info` matches the image tag (semver for `v*` tags, branch name for master, `pr-N` for PRs). This is where the released image is built.
- **`Dockerfile`** — `ARG VERSION=dev` + `-ldflags -X`.
- **`Makefile`** — local `image` target derives `VERSION` from `git describe`.

The `ARG VERSION=dev` default keeps the cyclonus/e2e local image builds (which don't pass the arg) working.

## Tests

Adds a test asserting the version reaches the `wigglenet_build_info` metric label. (`go.mod` gains `godebug` as an indirect dep, pulled in by prometheus `testutil`.)