### PR TITLE
fix(controller): don't panic in FirewallOnly/NativeRouting at startup

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -82,10 +82,8 @@ func NewController(clientset kubernetes.Interface, wireguardManager wireguard.Ma
 // processChanges gets called on any change to a node object as well as additions and removals.
 // it computes the new state of the world and adjust the local networking setup accordingly
 func (c *controller) processChanges(ctx context.Context, key string) error {
-	if !config.FirewallOnly && !config.NativeRouting {
-		if err := c.applyWireguardConfiguration(ctx); err != nil {
-			return err
-		}
+	if err := c.applyWireguardConfiguration(ctx); err != nil {
+		return err
 	}
 
 	if err := c.applyFirewallRules(); err != nil {
@@ -132,6 +130,10 @@ func (c *controller) applyFirewallRules() error {
 // applyWireguardConfiguration configures the Wireguard network interface and makes
 // appropriate changes to the routing table.
 func (c *controller) applyWireguardConfiguration(ctx context.Context) error {
+	if c.wireguard == nil {
+		return nil
+	}
+
 	logger := klog.FromContext(ctx)
 
 	nodes, err := c.nodeLister.List(labels.Everything())

--- a/internal/controller/firewallonly_test.go
+++ b/internal/controller/firewallonly_test.go
@@ -1,0 +1,26 @@
+package controller
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
+)
+
+// FirewallOnly/NativeRouting run with a nil wireguard.Manager; the startup
+// reconcile must be a no-op, not a panic.
+func TestApplyWireguardConfigurationNilManager(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	c := &controller{
+		nodeLister:     listersv1.NewNodeLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+		wireguard:      nil,
+		podCIDRUpdates: make(chan []netip.Prefix, 1),
+	}
+
+	assert.NotPanics(t, func() {
+		assert.NoError(t, c.applyWireguardConfiguration(ctx))
+	})
+}


### PR DESCRIPTION
## Bug

FirewallOnly and NativeRouting construct the controller with a nil `wireguard.Manager`, but `controller.Run` calls `applyWireguardConfiguration` unconditionally at startup (only `processChanges`/`ensureCNI` were guarded by the mode flags). That function ends in `c.wireguard.ApplyConfiguration(...)`, so on a nil `Manager` interface it panics with a nil-pointer dereference — and `runtime.HandleCrash` re-panics by default, taking the process down. Both modes crash-loop on startup.

Confirmed empirically (the added test panics against the unfixed code: `invalid memory address or nil pointer dereference` at the `ApplyConfiguration` call).

## History

Present since FirewallOnly was introduced (#1): that commit added the `!FirewallOnly && !NativeRouting` guard to `processChanges` and the `!FirewallOnly` guard to the CNI path, but never to the `Run()` startup sync. `git log -G'FirewallOnly|NativeRouting'` on the controller shows #1 is the only commit that ever touched those guards.

## Fix

Make `applyWireguardConfiguration` self-guard (`return nil` when there is no manager), fixing the startup path and any future caller. Since `c.wireguard == nil` is exactly equivalent to `FirewallOnly || NativeRouting`, the now-redundant config guard in `processChanges` is dropped — the controller no longer needs to consult mode flags to decide whether to configure WireGuard, removing the footgun that caused this bug.

Adds a regression test asserting the nil-manager path is a no-op.

(Rebased on top of #24; the guard applies to the lister-based `applyWireguardConfiguration`, which had reintroduced the unguarded call.)